### PR TITLE
Updated example script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is an implementation of the logistic regression. When there are more than 2
 ## Usage
 
 ```js
+const LogisticRegression = require('ml-logistic-regression');
 const { Matrix } = require('ml-matrix');
 
 // Our training set (X,Y).


### PR DESCRIPTION
I added `const LogisticRegression = require('ml-logistic-regression');` to the README example, as users ran into the issue where they ran the example but didn't add this line, causing an error (i.e #8)